### PR TITLE
add emitters for "error" and "offline"

### DIFF
--- a/lib/homieDevice.js
+++ b/lib/homieDevice.js
@@ -116,6 +116,14 @@ proto.setup = function(quiet) {
     t.onDisconnect();
   })
 
+  t.mqttClient.on('offline', function() {
+    t.onOffline();
+  })
+
+  t.mqttClient.on('error', function(err) {
+    t.onError(err);
+  })
+  
   t.mqttClient.on('message', function (topic, message) {
     if(message != null) {
       t.onMessage(topic, message.toString());
@@ -196,6 +204,18 @@ proto.onDisconnect = function() {
     node.onDisconnect();
   })
   t.emit('disconnect');
+}
+
+// Called on mqtt client offline
+proto.onOffline = function() {
+  var t = this;
+  t.emit('offline');
+}
+
+// Called on mqtt client error
+proto.onError = function(err) {
+  var t = this;
+  t.emit('error', err);
 }
 
 // Called on every stats interval


### PR DESCRIPTION
Registering a listener on "error" allows addressing the following issue with onStatsInterval when the interval is triggered while end() is processing. If the "error" event is not handled, the process with exit.

...\node_modules\mqtt\lib\client.js:370
      this.emit('error', new Error('client disconnecting'))
                         ^
Error: client disconnecting
    at MqttClient._checkDisconnecting (...\node_modules\mqtt\lib\client.js:370:26)
    at MqttClient.publish (...\node_modules\mqtt\lib\client.js:408:12)
    at module.exports.proto.onStatsInterval (...\node_modules\homie-device\lib\homieDevice.js:205:16)
    at module.exports.proto.onConnect (...\node_modules\homie-device\lib\homieDevice.js:182:5)
    at MqttClient.<anonymous> (...\node_modules\homie-device\lib\homieDevice.js:112:7)
    at MqttClient.emit (events.js:201:15)
    at MqttClient._handleConnack (...\node_modules\mqtt\lib\client.js:918:10)
    at MqttClient._handlePacket (...\node_modules\mqtt\lib\client.js:350:12)
    at work (...\node_modules\mqtt\lib\client.js:292:12)
    at Writable.writable._write (...\node_modules\mqtt\lib\client.js:302:5)
    at doWrite (...\node_modules\readable-stream\lib\_stream_writable.js:428:64)
    at writeOrBuffer (...\node_modules\readable-stream\lib\_stream_writable.js:417:5)
    at Writable.write (...\node_modules\readable-stream\lib\_stream_writable.js:334:11)
    at Socket.ondata (_stream_readable.js:696:22)
    at Socket.emit (events.js:196:13)
    at addChunk (_stream_readable.js:290:12)
    at readableAddChunk (_stream_readable.js:271:11)
    at Socket.Readable.push (_stream_readable.js:226:10)
    at TCP.onStreamRead (internal/stream_base_commons.js:166:17)